### PR TITLE
Fixed travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 sudo: false
 language: go
 go:
-- 1.6.4
-- 1.7.4
+- 1.7.x
+- 1.8.x
 env:
   global:
   - ORG_PATH=/home/travis/gopath/src/github.com/intelsdi-x
@@ -13,7 +13,7 @@ env:
   - TEST_TYPE=build
 matrix:
   exclude:
-  - go: 1.6.4
+  - go: 1.7.x
     env: TEST_TYPE=build
 before_install:
 - "[[ -d $SNAP_PLUGIN_SOURCE ]] || mkdir -p $ORG_PATH && ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE"


### PR DESCRIPTION
Fixed travis config so it uses go 1.7.x and 1.8.x.
New lib-go doesn't support 1.6.x so travis tests failed.